### PR TITLE
Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: python
+
+python:
+  - '2.7'
+  - '3.3'
+  - '2.6'
+
+script:
+  - python setup.py test
+

--- a/setup.py
+++ b/setup.py
@@ -2,12 +2,17 @@
 
 from setuptools import setup
 
+dependency_links=[
+    'git+https://github.com/Toblerity/Shapely.git@maint#egg=Shapely',
+]
+
 setup(name='libhxl',
       version='0.10',
       description='Python support for the Humanitarian Exchange Language (HXL).',
       author='David Megginson',
       url='http://hxlproject.org',
       install_requires=['shapely', 'python-dateutil'],
+      dependency_links=dependency_links,
       packages=['hxl', 'hxl.filters'],
       test_suite='tests',
       scripts=[

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,6 @@
 #!/usr/bin/python
 
-try:
-    from setuptools import setup
-except ImportError:
-    from distutils.core import setup
+from setuptools import setup
 
 setup(name='libhxl',
       version='0.10',
@@ -12,6 +9,7 @@ setup(name='libhxl',
       url='http://hxlproject.org',
       install_requires=['shapely', 'python-dateutil'],
       packages=['hxl', 'hxl.filters'],
+      test_suite='tests',
       scripts=[
         'scripts/hxl2geojson',
         'scripts/hxladd',


### PR DESCRIPTION
Travis builds operational at
https://travis-ci.org/jayvdb/libhxl-python/builds/47611776

I can revert the change re distutils.core.setup , but it is extremely unlikely that someone has Shapely installed but not setuptools.