### PR TITLE
Remove structlog dependancy constraint

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ python-io-wrapper>=0.2
 urllib3<1.27,>=1.21.1
 jsonpath-ng
 ply
-structlog==22.1.0
+structlog

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
         'jsonpath_ng',
         'urllib3<1.27,>=1.21.1',
         'ply',
-        'structlog==22.1.0',
+        'structlog',
     ],
     packages=['hxl', 'hxl.formulas'],
     package_data={'hxl': ['*.json']},


### PR DESCRIPTION
Having the structlog dependancy pinned to an exact version is problematic when trying to use this library in actual projects that also/already use structlog, because they don't have this exact version in use. I don't think there is an actual reason to restrict it that much, so removed the constraint here (similar to how it's done for e.g. the requests library).