### PR TITLE
Hxl 69

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 Release 5.0
 	- fix URL munging for direct-download HXL Proxy URLs
+	- add hxlinfo command-line script
 
 2023-04-06 Release 4.29
 	- remove hxl.input.ExcelInput.info() and make a top-level hxl.input.info() function that works with every data type (also alias to hxl.info())

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 Release 5.0
 	- fix URL munging for direct-download HXL Proxy URLs
 	- add hxlinfo command-line script
+	- renamed hxl_headers field in output of hxl.input.info() to hxl_hashtags
+	- added headers, hxl_headers, and hxl_hashtags fields to output of hxl.input.info()
 
 2023-04-06 Release 4.29
 	- remove hxl.input.ExcelInput.info() and make a top-level hxl.input.info() function that works with every data type (also alias to hxl.info())

--- a/hxl/input.py
+++ b/hxl/input.py
@@ -902,7 +902,7 @@ class AbstractInput(object):
     def __init__(self, input_options, url_or_filename=None):
         super().__init__()
         self.input_options = input_options
-        self.url_or_filename = None
+        self.url_or_filename = url_or_filename
         self.is_repeatable = False
 
     @abc.abstractmethod

--- a/hxl/input.py
+++ b/hxl/input.py
@@ -279,9 +279,15 @@ def info(data, input_options=None):
         # See if the first 25 rows are HXLated
         try:
             source = HXLReader(opening_rows)
-            hxl_header_hash = source.columns_hash
+            hxl_headers = [column.header for column in source.columns]
+            hxl_hashtags = [column.display_tag for column in source.columns]
+            hxl_header_hash = hash_row(hxl_headers)
+            hxl_hashtag_hash = source.columns_hash
         except HXLTagsNotFoundException:
+            hxl_headers = None
+            hxl_hashtags = None
             hxl_header_hash = None
+            hxl_hashtag_hash = None
                 
         result["sheets"] = [
             {
@@ -293,6 +299,10 @@ def info(data, input_options=None):
                 "is_hxlated": hxl_header_hash is not None,
                 "header_hash": hash_row(opening_rows[0]) if nrows > 0 else None,
                 "hxl_header_hash": hxl_header_hash,
+                "hxl_hashtag_hash": hxl_hashtag_hash,
+                "headers": opening_rows[0],
+                "hxl_headers": hxl_headers,
+                "hxl_hashtags": hxl_hashtags,
             },
         ]
 
@@ -1206,6 +1216,8 @@ class ExcelInput(AbstractInput):
         for sheet_index in range(0, self._workbook.nsheets):
             sheet = self._get_sheet(sheet_index)
             columns = self._get_columns(sheet)
+            hxl_headers = [column.header for column in columns] if columns else None
+            hxl_hashtags = [column.display_tag for column in columns] if columns else None
             sheet_info = {
                 "name": sheet.name,
                 "is_hidden": (sheet.visibility > 0),
@@ -1214,7 +1226,11 @@ class ExcelInput(AbstractInput):
                 "has_merged_cells": (len(sheet.merged_cells) > 0),
                 "is_hxlated": (columns is not None),
                 "header_hash": hash_row(self._get_row(sheet, 0)) if sheet.nrows > 0 else None,
-                "hxl_header_hash": hxl.model.Column.hash_list(columns) if columns else None,
+                "hxl_header_hash": hash_row(hxl_headers) if hxl_headers else None,
+                "hxl_hashtag_hash": hxl.model.Column.hash_list(columns) if columns else None,
+                "headers": self._get_row(sheet, 0) if sheet.nrows > 0 else None,
+                "hxl_headers": hxl_headers,
+                "hxl_hashtags": hxl_hashtags,
             }
             result.append(sheet_info)
         return result

--- a/hxl/scripts.py
+++ b/hxl/scripts.py
@@ -1434,7 +1434,7 @@ def hxlinfo_main(args, stdin=STDIN, stdout=sys.stdout, stderr=sys.stderr):
 
     do_common_args(args)
 
-    json.dump(hxl.input.info(args.infile or stdin, make_input_options(args)), stdout, indent=2)
+    json.dump(hxl.input.info(args.infile or stdin, make_input_options(args)), stdout, indent=2, ensure_ascii=False)
 
     return EXIT_OK
 

--- a/hxl/scripts.py
+++ b/hxl/scripts.py
@@ -50,6 +50,7 @@ __all__ = (
     'hxlfill',
     'hxlimplode',
     'hxlhash',
+    'hxlinfo',
     'hxlmerge',
     'hxlrename',
     'hxlreplace',
@@ -433,6 +434,43 @@ options:
 
 """
     run_script(hxlhash_main)
+
+
+def hxlinfo():
+    """ Entry point for hxlhash console script
+``` none
+usage: hxlinfo [-h] [--encoding [string]] [--sheet [number]]
+               [--selector [path]] [--http-header header]
+               [--ignore-certs] [--expand-merged] [--scan-ckan-resources]
+               [--log debug|info|warning|error|critical|none] [-H]
+               [infile]
+
+Return metadata for a data source in JSON format (the source does not have to be HXLated).
+
+positional arguments:
+  infile                HXL file to read (if omitted, use standard
+                        input).
+
+options:
+  -h, --help            show this help message and exit
+  --encoding [string]   Specify the character encoding of the input
+  --sheet [number]      Select sheet from a workbook (1 is first sheet)
+  --selector [path]     JSONPath expression for starting point in JSON
+                        input
+  --http-header header  Custom HTTP header to send with request
+  --ignore-certs        Don't verify SSL connections (useful for self-
+                        signed)
+  --expand-merged       Expand merged areas by repeating the value (Excel
+                        only)
+  --scan-ckan-resources
+                        For a CKAN dataset URL, scan all CKAN resources
+                        for one that's HXLated
+  --log debug|info|warning|error|critical|none
+                        Set minimum logging level
+```
+
+"""
+    run_script(hxlinfo_main)
 
 
 def hxlmerge():
@@ -1375,6 +1413,28 @@ def hxlhash_main(args, stdin=STDIN, stdout=sys.stdout, stderr=sys.stderr):
             print(source.columns_hash)
         else:
             print(source.data_hash)
+
+    return EXIT_OK
+
+
+def hxlinfo_main(args, stdin=STDIN, stdout=sys.stdout, stderr=sys.stderr):
+    """ Run hxlinfo with command-line arguments.
+
+    Display metadata for a data source.
+
+    Produces non-HXLated JSON output.
+
+    """
+    parser = make_args(
+        'Display JSON-formatted metadata for a data source (does not have to be HXLated).',
+        hxl_output=False
+    )
+
+    args = parser.parse_args(args)
+
+    do_common_args(args)
+
+    json.dump(hxl.input.info(args.infile or stdin, make_input_options(args)), stdout, indent=2)
 
     return EXIT_OK
 

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@ setup(
             'hxlfill = hxl.scripts:hxlfill',
             'hxlimplode = hxl.scripts:hxlimplode',
             'hxlhash = hxl.scripts:hxlhash',
+            'hxlinfo = hxl.scripts:hxlinfo',
             'hxlmerge = hxl.scripts:hxlmerge',
             'hxlrename = hxl.scripts:hxlrename',
             'hxlreplace = hxl.scripts:hxlreplace',

--- a/tests/test_input.py
+++ b/tests/test_input.py
@@ -176,7 +176,7 @@ class TestInput(unittest.TestCase):
         self.assertTrue(report["sheets"][0]["has_merged_cells"])
         self.assertFalse(report["sheets"][0]["is_hxlated"])
         self.assertEqual("56c6270ee039646436af590e874e6f67", report["sheets"][0]["header_hash"])
-        self.assertTrue(report["sheets"][0]["hxl_header_hash"] is None)
+        self.assertTrue(report["sheets"][0]["hxl_hashtag_hash"] is None)
 
         # Sheet 2
         self.assertEqual("input-quality-hxl", report["sheets"][1]["name"])
@@ -186,7 +186,7 @@ class TestInput(unittest.TestCase):
         self.assertFalse(report["sheets"][1]["has_merged_cells"])
         self.assertTrue(report["sheets"][1]["is_hxlated"])
         self.assertEqual("56c6270ee039646436af590e874e6f67", report["sheets"][1]["header_hash"])
-        self.assertEqual("3252897e927737b2f6f423dccd07ac93", report["sheets"][1]["hxl_header_hash"])
+        self.assertEqual("3252897e927737b2f6f423dccd07ac93", report["sheets"][1]["hxl_hashtag_hash"])
 
     def test_xls_info(self):
         report = hxl.input.info(FILE_XLS_INFO, InputOptions(allow_local=True))
@@ -201,7 +201,7 @@ class TestInput(unittest.TestCase):
         #self.assertTrue(report["sheets"][0]["has_merged_cells"]) # can't detect in XLS yet
         self.assertFalse(report["sheets"][0]["is_hxlated"])
         self.assertEqual("56c6270ee039646436af590e874e6f67", report["sheets"][0]["header_hash"])
-        self.assertTrue(report["sheets"][0]["hxl_header_hash"] is None)
+        self.assertTrue(report["sheets"][0]["hxl_hashtag_hash"] is None)
 
         # Sheet 2
         self.assertEqual("input-quality-hxl", report["sheets"][1]["name"])
@@ -211,10 +211,79 @@ class TestInput(unittest.TestCase):
         self.assertFalse(report["sheets"][1]["has_merged_cells"])
         self.assertTrue(report["sheets"][1]["is_hxlated"])
         self.assertEqual("56c6270ee039646436af590e874e6f67", report["sheets"][1]["header_hash"])
-        self.assertEqual("3252897e927737b2f6f423dccd07ac93", report["sheets"][1]["hxl_header_hash"])
+        self.assertEqual("3252897e927737b2f6f423dccd07ac93", report["sheets"][1]["hxl_hashtag_hash"])
+
+    def test_excel_info(self):
+        HEADERS = ['¿Qué?', '', '', '¿Quién?', '¿Para quién?', '', '¿Dónde?', '¿Cuándo?',]
+        HXL_HEADERS = [
+            "Registro",
+            "Sector/Cluster",
+            "Subsector",
+            "Organización",
+            "Hombres",
+            "Mujeres",
+            "País",
+            "Departamento/Provincia/Estado",
+            None,
+        ]
+        HXL_HASHTAGS = [
+            "",
+            "#sector+es",
+            "#subsector+es",
+            "#org+es",
+            "#targeted+f",
+            "#targeted+m",
+            "#country",
+            "#adm1",
+            "#date+reported",
+        ]
+        
+        report = hxl.input.info(FILE_XLSX, InputOptions(allow_local=True))
+        self.assertEqual(FILE_XLSX, report["url_or_filename"])
+        self.assertEqual("XLSX", report["format"])
+        self.assertEqual(1, len(report["sheets"]))
+
+        sheet = report["sheets"][0]
+        self.assertEqual("input-valid", sheet["name"])
+        self.assertEqual(7, sheet["nrows"])
+        self.assertEqual(9, sheet["ncols"])
+        self.assertFalse(sheet["is_hidden"])
+        self.assertTrue(sheet["has_merged_cells"])
+        self.assertTrue(sheet["is_hxlated"])
+        self.assertEqual("b1c179c6f56b75507e1775ac4b7025d5", sheet["header_hash"])
+        self.assertEqual("56c6270ee039646436af590e874e6f67", sheet["hxl_header_hash"])
+        self.assertEqual("3252897e927737b2f6f423dccd07ac93", sheet["hxl_hashtag_hash"])
+        self.assertEqual(HEADERS, sheet["headers"])
+        self.assertEqual(HXL_HEADERS, sheet["hxl_headers"])
+        self.assertEqual(HXL_HASHTAGS, sheet["hxl_hashtags"])
 
     def test_csv_info(self):
+        HEADERS = ['Qué?', '', '', 'Quién?', 'Para quién?', '', 'Dónde?', 'Cuándo?']
+        HXL_HEADERS = [
+            "Registro",
+            "Sector/Cluster",
+            "Subsector",
+            "Organización",
+            "Hombres",
+            "Mujeres",
+            "País",
+            "Departamento/Provincia/Estado",
+            None,
+        ]
+        HXL_HASHTAGS = [
+            "",
+            "#sector+es",
+            "#subsector+es",
+            "#org+es",
+            "#targeted+f",
+            "#targeted+m",
+            "#country",
+            "#adm1",
+            "#date+reported",
+        ]
+        
         report = hxl.input.info(FILE_CSV, InputOptions(allow_local=True))
+        #self.assertEqual(FILE_CSV, report["url_or_filename"])
         self.assertEqual("CSV", report["format"])
         self.assertEqual(1, len(report["sheets"]))
 
@@ -226,7 +295,11 @@ class TestInput(unittest.TestCase):
         self.assertFalse(sheet["has_merged_cells"])
         self.assertTrue(sheet["is_hxlated"])
         self.assertEqual("88d0fd57e1dbfe721e41b7ab48248feb", sheet["header_hash"])
-        self.assertEqual("3252897e927737b2f6f423dccd07ac93", sheet["hxl_header_hash"])
+        self.assertEqual("56c6270ee039646436af590e874e6f67", sheet["hxl_header_hash"])
+        self.assertEqual("3252897e927737b2f6f423dccd07ac93", sheet["hxl_hashtag_hash"])
+        self.assertEqual(HEADERS, sheet["headers"])
+        self.assertEqual(HXL_HEADERS, sheet["hxl_headers"])
+        self.assertEqual(HXL_HASHTAGS, sheet["hxl_hashtags"])
 
     def test_json_arrays_info(self):
         report = hxl.input.info(FILE_JSON, InputOptions(allow_local=True))
@@ -240,7 +313,7 @@ class TestInput(unittest.TestCase):
         self.assertFalse(sheet["has_merged_cells"])
         self.assertTrue(sheet["is_hxlated"])
         self.assertEqual("88d0fd57e1dbfe721e41b7ab48248feb", sheet["header_hash"])
-        self.assertEqual("3252897e927737b2f6f423dccd07ac93", sheet["hxl_header_hash"])
+        self.assertEqual("3252897e927737b2f6f423dccd07ac93", sheet["hxl_hashtag_hash"])
 
     def test_json_objects_info(self):
         report = hxl.input.info(FILE_JSON_OBJECTS, InputOptions(allow_local=True))
@@ -254,7 +327,7 @@ class TestInput(unittest.TestCase):
         self.assertFalse(sheet["has_merged_cells"])
         self.assertTrue(sheet["is_hxlated"])
         self.assertEqual("ccfd7a84d6697a870e95dd64fbac640c", sheet["header_hash"])
-        self.assertEqual("ccfd7a84d6697a870e95dd64fbac640c", sheet["hxl_header_hash"])
+        self.assertEqual("ccfd7a84d6697a870e95dd64fbac640c", sheet["hxl_hashtag_hash"])
 
     def test_ckan_resource(self):
         source = hxl.data('https://data.humdata.org/dataset/hxl-master-vocabulary-list/resource/d22dd1b6-2ff0-47ab-85c6-08aeb911a832')


### PR DESCRIPTION
Updates for HXL-69. Now supports headers, hxl_headers, and hxl_hashtags fields.